### PR TITLE
`/_next/static` を NGINX で配信

### DIFF
--- a/webapp/docker-compose.local.yml
+++ b/webapp/docker-compose.local.yml
@@ -77,6 +77,7 @@ services:
     volumes:
       - ./nginx/nginx.local.conf:/etc/nginx/nginx.conf
       - nginx-logs:/var/log/nginx
+      - ./frontend/.next/static:/app/frontend/.next/static
     tmpfs:
       - /var/cache/nginx
     networks:

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -37,6 +37,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+    volumes:
+      - frontend-files:/usr/src/frontend
     healthcheck:
       test: ["CMD", "curl", "-I", "http://localhost:3000/health-check", "-X", "GET"]
       interval: 5s
@@ -83,6 +85,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - /da/tls:/da/tls:ro
       - nginx-logs:/var/log/nginx
+      - frontend-files:/usr/src/frontend
     tmpfs:
       - /var/cache/nginx
     networks:
@@ -173,6 +176,7 @@ networks:
     external: true
 
 volumes:
+  frontend-files:
   nginx-logs:
     external: true
   mysql-logs:

--- a/webapp/nginx/nginx.conf
+++ b/webapp/nginx/nginx.conf
@@ -94,6 +94,13 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /_next/static {
+            alias /usr/src/frontend/.next/static;
+            try_files $uri =404;
+            add_header Cache-Control "public";
+            expires 1d;
+        }
+
         location /api/ {
             proxy_set_header Connection "";
             proxy_http_version 1.1;

--- a/webapp/nginx/nginx.local.conf
+++ b/webapp/nginx/nginx.local.conf
@@ -88,6 +88,13 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # favicon.ico は 304 が返ってるので一旦放置
+        location /_next/static {
+            alias /app/frontend/.next/static;
+            try_files $uri $uri/ =404;
+            expires 1d;
+        }
+
         # Next.jsのホットリロード設定
         location /_next/webpack-hmr {
             proxy_pass http://frontend/_next/webpack-hmr;

--- a/webapp/nginx/nginx.local.conf
+++ b/webapp/nginx/nginx.local.conf
@@ -92,6 +92,7 @@ http {
         location /_next/static {
             alias /app/frontend/.next/static;
             try_files $uri $uri/ =404;
+            add_header Cache-Control "public";
             expires 1d;
         }
 


### PR DESCRIPTION
## 関連 Issue

<!-- close #00 と書くと、Issue がリンクされます -->
<!-- 自分が担当する Issue の番号を入力してください -->
close #12 

## 変更点

<!-- 変更の概要、注意点 -->
- タイトル通り
- favicon は既に 304 が付いていたので、nextjs から配信させたまま

そもそも nextjs にキャッシュさせる方法がないのか?

## パフォーマンスの変化

<!-- レイテンシが改善した、CPU 使用率が下がった、など -->
<!-- スクリーンショットがあるとよい -->

ファイル配信のレイテンシが下がった

## チェックリスト

- [x] パフォーマンスに何らかの変化がある (変更を正しく反映しているか)
- [x] テスト、ベンチマークでエラーが出ない

## 補足

<!-- 補足事項があれば -->
