### PR TITLE
画像をX-Accel-Redirectで配信

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -62,7 +62,8 @@ tasks:
   checkout:
     desc: リモートブランチに強制的にチェックアウト
     vars:
-      BRANCH: '{{.CLI_ARGS | default "main"}}'
+      BRANCH:
+        sh: if [[ -z "{{.CLI_ARGS}}" ]]; then git branch --show-current; else echo "{{.CLI_ARGS}}"; fi
     cmds:
       - git fetch --all
       - git reset --hard origin/{{.BRANCH}}

--- a/webapp/backend/Cargo.lock
+++ b/webapp/backend/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "futures-util",
+ "image",
  "log",
  "rand",
  "serde",
@@ -430,6 +431,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -489,6 +496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +552,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -609,6 +628,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +660,12 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -744,6 +788,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "exr"
+version = "1.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
+dependencies = [
+ "bit_field",
+ "flume",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +820,15 @@ checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -855,6 +933,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,6 +965,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -999,6 +1097,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "jpeg-decoder",
+ "num-traits",
+ "png",
+ "qoi",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1205,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin 0.9.8",
 ]
+
+[[package]]
+name = "lebe"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
@@ -1161,6 +1292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1397,6 +1529,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "png"
+version = "0.17.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1454,6 +1608,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1686,6 +1860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1901,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -1890,6 +2073,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -2189,6 +2383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,4 +2610,13 @@ checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
 ]

--- a/webapp/backend/Cargo.toml
+++ b/webapp/backend/Cargo.toml
@@ -19,6 +19,7 @@ argon2 = "0.5.3"
 futures-util = "0.3.30"
 log = "0.4.22"
 actix-files = "0.6.6"
+image = "0.24.9"
 
 [build-dependencies]
 syn = "1"

--- a/webapp/backend/images/user_profile/.gitignore
+++ b/webapp/backend/images/user_profile/.gitignore
@@ -1,0 +1,1 @@
+resized_*.png

--- a/webapp/backend/src/api/auth_handler.rs
+++ b/webapp/backend/src/api/auth_handler.rs
@@ -42,8 +42,8 @@ pub async fn user_profile_image_handler(
     path: web::Path<i32>,
 ) -> Result<HttpResponse, AppError> {
     let user_id = path.into_inner();
-    let profile_image_byte = service.get_resized_profile_image_byte(user_id).await?;
+    let profile_image_path = service.get_resized_profile_image_path(user_id).await?;
     Ok(HttpResponse::Ok()
-        .content_type("image/png")
-        .body(profile_image_byte))
+        .append_header(("X-Accel-Redirect", profile_image_path))
+        .finish())
 }

--- a/webapp/docker-compose.local.yml
+++ b/webapp/docker-compose.local.yml
@@ -19,7 +19,8 @@ services:
       timeout: 10s
       retries: 10
       start_period: 600s
-    entrypoint: ["sh", "-c", "cargo watch -x run"]
+    # dev 環境での画像リサイズ時の再ビルドを防止する
+    entrypoint: ["sh", "-c", "cargo watch -x run --ignore images"]
 
   frontend:
     container_name: frontend
@@ -78,6 +79,7 @@ services:
       - ./nginx/nginx.local.conf:/etc/nginx/nginx.conf
       - nginx-logs:/var/log/nginx
       - ./frontend/.next/static:/app/frontend/.next/static
+      - ./backend/images:/usr/src/backend/images
     tmpfs:
       - /var/cache/nginx
     networks:

--- a/webapp/docker-compose.local.yml
+++ b/webapp/docker-compose.local.yml
@@ -77,6 +77,7 @@ services:
     volumes:
       - ./nginx/nginx.local.conf:/etc/nginx/nginx.conf
       - nginx-logs:/var/log/nginx
+      - ./frontend/.next/static:/app/frontend/.next/static
     tmpfs:
       - /var/cache/nginx
     networks:

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - user-icons:/usr/local/bin/images
     healthcheck:
       test: ["CMD", "curl", "-I", "http://localhost:8080/api/health_check", "-X", "GET"]
       interval: 5s
@@ -86,6 +88,7 @@ services:
       - /da/tls:/da/tls:ro
       - nginx-logs:/var/log/nginx
       - frontend-files:/usr/src/frontend
+      - user-icons:/usr/local/bin/images
     tmpfs:
       - /var/cache/nginx
     networks:
@@ -176,6 +179,7 @@ networks:
     external: true
 
 volumes:
+  user-icons: # external でもいいかも
   frontend-files:
   nginx-logs:
     external: true

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -37,6 +37,8 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+    volumes:
+      - frontend-files:/usr/src/frontend
     healthcheck:
       test: ["CMD", "curl", "-I", "http://localhost:3000/health-check", "-X", "GET"]
       interval: 5s
@@ -83,6 +85,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - /da/tls:/da/tls:ro
       - nginx-logs:/var/log/nginx
+      - frontend-files:/usr/src/frontend
     tmpfs:
       - /var/cache/nginx
     networks:
@@ -173,6 +176,7 @@ networks:
     external: true
 
 volumes:
+  frontend-files:
   nginx-logs:
     external: true
   mysql-logs:

--- a/webapp/nginx/nginx.conf
+++ b/webapp/nginx/nginx.conf
@@ -101,6 +101,12 @@ http {
             expires 1d;
         }
 
+        location /protected/ {
+            internal;
+            alias /usr/local/bin/images/user_profile/;
+            expires 1d;
+        }
+
         location /api/ {
             proxy_set_header Connection "";
             proxy_http_version 1.1;

--- a/webapp/nginx/nginx.conf
+++ b/webapp/nginx/nginx.conf
@@ -94,6 +94,13 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /_next/static {
+            alias /usr/src/frontend/.next/static;
+            try_files $uri =404;
+            add_header Cache-Control "public";
+            expires 1d;
+        }
+
         location /api/ {
             proxy_set_header Connection "";
             proxy_http_version 1.1;

--- a/webapp/nginx/nginx.local.conf
+++ b/webapp/nginx/nginx.local.conf
@@ -104,6 +104,11 @@ http {
             proxy_set_header Connection "upgrade";
         }
 
+        location /protected/ {
+            internal;
+            alias /usr/src/backend/images/user_profile/;
+            expires 1d;
+        }
 
         location /api/ {
             proxy_set_header Connection "";

--- a/webapp/nginx/nginx.local.conf
+++ b/webapp/nginx/nginx.local.conf
@@ -88,6 +88,13 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # favicon.ico は 304 が返ってるので一旦放置
+        location /_next/static {
+            alias /app/frontend/.next/static;
+            try_files $uri $uri/ =404;
+            expires 1d;
+        }
+
         # Next.jsのホットリロード設定
         location /_next/webpack-hmr {
             proxy_pass http://frontend/_next/webpack-hmr;

--- a/webapp/nginx/nginx.local.conf
+++ b/webapp/nginx/nginx.local.conf
@@ -92,6 +92,7 @@ http {
         location /_next/static {
             alias /app/frontend/.next/static;
             try_files $uri $uri/ =404;
+            add_header Cache-Control "public";
             expires 1d;
         }
 


### PR DESCRIPTION
## 関連 Issue

<!-- close #00 と書くと、Issue がリンクされます -->
<!-- 自分が担当する Issue の番号を入力してください -->
close #10 
close #11 

## 変更点

<!-- 変更の概要、注意点 -->

- 画像は認証エンドポイントなのでそのままではキャッシュできない
- アプリケーションから `X-Accel-Redirect` ヘッダーを返し、NGINX からリサイズ後のアイコンを配信する

開発環境では `cargo watch` が `images/` の変更に反応して再ビルドされていたので、直した。
そもそも画像をキャッシュしていいかは改めて考える。ログアウト後も表示できてしまうため。

## パフォーマンスの変化

<!-- レイテンシが改善した、CPU 使用率が下がった、など -->
<!-- スクリーンショットがあるとよい -->

画像をキャッシュできるようになった。

## チェックリスト

- [x] パフォーマンスに何らかの変化がある (変更を正しく反映しているか)
- [x] テスト、ベンチマークでエラーが出ない

## 補足

<!-- 補足事項があれば -->
